### PR TITLE
Add per-song update lock, retry with rate limit handling, token refreshing, and fix bug with logged index

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The script supports various options for flexible usage. Below are examples of ho
 - `-b, --album ALBUM_ID`: Process a specific album. Multiple albums can be specified.
 - `-s, --start START_INDEX`: Start processing from the artist at the specified index (0-based).
 - `-l, --limit LIMIT`: Limit the processing to a specific number of artists from the start index.
+- `-d, --cache-duration DURATION`: Number of days to cache song updates (0 to force update every time).
 
 ### Command Formats
 

--- a/sptnr.py
+++ b/sptnr.py
@@ -570,8 +570,13 @@ TOTAL_BLOCKS = 20
 color_found = LIGHT_GREEN if FOUND_AND_UPDATED == TOTAL_TRACKS else LIGHT_YELLOW
 color_found_white = LIGHT_GREEN if FOUND_AND_UPDATED == TOTAL_TRACKS else BOLD
 color_not_found = LIGHT_GREEN if NOT_FOUND == 0 else LIGHT_RED
-blocks_found = "█" * round(FOUND_AND_UPDATED * TOTAL_BLOCKS / TOTAL_TRACKS)
-blocks_not_found = "█" * (TOTAL_BLOCKS - len(blocks_found))
+
+if TOTAL_TRACKS == 0:
+    blocks_found = ""
+    blocks_not_found = ""
+else:
+    blocks_found = "█" * round(FOUND_AND_UPDATED * TOTAL_BLOCKS / TOTAL_TRACKS)
+    blocks_not_found = "█" * (TOTAL_BLOCKS - len(blocks_found))
 full_blocks_found = f"{color_found_white}{blocks_found}{RESET}"
 full_blocks_not_found = f"{color_not_found}{blocks_not_found}{RESET}"
 

--- a/sptnr.py
+++ b/sptnr.py
@@ -26,7 +26,9 @@ if os.path.exists(".env"):
 # Record the start time
 start_time = time.time()
 
-LOCK_FILE = "song_update_lock.json"
+LOCK_DIR = "logs"
+LOCK_FILENAME = "song_update_lock.json"
+LOCK_FILE = LOCK_DIR + "/" + LOCK_FILENAME
 
 # Config
 NAV_BASE_URL = os.getenv("NAV_BASE_URL")

--- a/sptnr.py
+++ b/sptnr.py
@@ -446,7 +446,7 @@ else:
 
         logging.info("")
         logging.info(
-            f"Artist: {LIGHT_PURPLE}{ARTIST_NAME}{RESET} ({ARTIST_ID})[{index}]"
+            f"Artist: {LIGHT_PURPLE}{ARTIST_NAME}{RESET} ({ARTIST_ID})[{index+args.start}]"
         )
         process_artist(ARTIST_ID)
 


### PR DESCRIPTION
This PR introduces several improvements and fixes.
## Features

### Per-song Update Lock
- Added a locking mechanism per song to prevent redundant updates & request to spotify API.
- Lock duration has a 24hr jitter to prevent a stampede.
- Lock duration is configurable via argument `-d`.
- Specifying a lock duration of 0 will force an update.

### Token Refreshing
- Spotify tokens expire after 60 minutes.
- Implemented automatic token refreshing 1minute before the token expires
- This ensures the Spotify token is always valid, and doesn't crash due to invalid token.

### Retry with Rate Limit Handling
- Added retry logic for Rate Limited requests, Spotify Errors, and Timeouts.
- This includes exponential backoff, and respecting the Retry-After header returned by Spotify

## Bug Fixes

### Output Index Fix
- Corrects the output index with using the `--start` argument.
- Ensures that the displayed index reflects the correct global position.


## Notes
- The locking allows the script to be re-run multiple times, only updating what is required, which is useful for libraries that are regularly updated.
- Retry and token refresh logic improves resilience against Spotify's API

## Related Issues
resolves #9 
resolves #8 
partially #3 